### PR TITLE
Add beta distribution implementation

### DIFF
--- a/config/continuous/beta.py
+++ b/config/continuous/beta.py
@@ -1,0 +1,11 @@
+import streamlit as st
+import torch
+
+BETA = {
+    "params": lambda: {
+        "alpha": st.sidebar.slider("Alpha (α)", 0.1, 10.0, 2.0, 0.1),
+        "beta": st.sidebar.slider("Beta (β)", 0.1, 10.0, 2.0, 0.1),
+    },
+    "dist": lambda p: torch.distributions.Beta(p["alpha"], p["beta"]),
+    "support": lambda p: (0, 1),
+}


### PR DESCRIPTION
This PR adds implementation for the Beta distribution in the continuous distributions section.

The Beta distribution is a continuous probability distribution defined on the interval [0, 1] 
with two positive shape parameters, alpha and beta.

- Added beta.py in config/continuous/ directory
- Implemented parameters with sliders for alpha and beta
- Set support range to (0, 1)