### PR TITLE
add cdf for all distributions

### DIFF
--- a/pages/Continuous.py
+++ b/pages/Continuous.py
@@ -2,7 +2,7 @@ import streamlit as st
 import torch
 import plotly.graph_objects as go
 from config.continuous import CONTINUOUS_DISTRIBUTIONS
-from utils import compute_pdf, plot_pdf
+from utils import compute_pdf, plot_pdf, compute_cdf, plot_cdf
 
 st.title("Continuous Distributions")
 
@@ -15,4 +15,5 @@ support = support(params) if callable(support) else None
 x_range = torch.linspace(-10, 10, 1000)
 pdf = compute_pdf(dist, x_range, support)
 plot_pdf(pdf, x_range, selected_dist)
+plot_cdf(compute_cdf(dist, x_range, support), x_range, selected_dist)
 

--- a/pages/Discrete.py
+++ b/pages/Discrete.py
@@ -2,7 +2,7 @@ import streamlit as st
 import torch
 import plotly.graph_objects as go
 from config.discrete import DISCRETE_DISTRIBUTIONS
-from utils import compute_pdf, plot_pmf, compute_cdf, plot_discrete_cdf
+from utils import compute_pdf, plot_pmf, compute_descrete_cdf, plot_discrete_cdf
 
 st.title("Discrete Distributions")
 
@@ -20,4 +20,4 @@ else:
 
 pmf = dist.log_prob(x_range).exp()
 plot_pmf(pmf, x_range, selected_dist)
-plot_discrete_cdf(compute_cdf(dist, x_range, support), x_range, selected_dist)
+plot_discrete_cdf(compute_descrete_cdf(pmf, x_range, support), x_range, selected_dist)

--- a/pages/Discrete.py
+++ b/pages/Discrete.py
@@ -2,7 +2,7 @@ import streamlit as st
 import torch
 import plotly.graph_objects as go
 from config.discrete import DISCRETE_DISTRIBUTIONS
-from utils import compute_pdf, plot_pmf
+from utils import compute_pdf, plot_pmf, compute_cdf, plot_discrete_cdf
 
 st.title("Discrete Distributions")
 
@@ -20,3 +20,4 @@ else:
 
 pmf = dist.log_prob(x_range).exp()
 plot_pmf(pmf, x_range, selected_dist)
+plot_discrete_cdf(compute_cdf(dist, x_range, support), x_range, selected_dist)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ streamlit
 torch
 plotly
 pandas
+scipy

--- a/utils.py
+++ b/utils.py
@@ -16,6 +16,12 @@ def compute_pdf(dist, x_range, support):
     pdf[mask] = dist.log_prob(x_range[mask]).exp()
     return pdf
 
+def compute_cdf(dist, x_range, support):
+    cdf = torch.zeros_like(x_range, dtype=torch.float)    
+    pdf = compute_pdf(dist, x_range, support)
+    cdf = pdf.cumsum(dim=0)
+    return cdf
+
 def plot_pdf(pdf, x_range, dist_name):
     # Main plot area
     st.markdown(f'#### Probability Density Function for {dist_name} Distribution')
@@ -33,5 +39,25 @@ def plot_pmf(pmf, x_range, dist_name):
     fig.add_trace(go.Bar(x=x_range.tolist(), y=pmf.tolist(),
                          name='', hovertemplate='x: %{x:.2f}<br>p(x): %{y:.2f}'))
     fig.update_layout(xaxis_title='x', yaxis_title='P(x)', showlegend=False)
+
+    st.plotly_chart(fig)
+
+def plot_cdf(cdf, x_range, dist_name):
+    # Main plot area
+    st.markdown(f'#### Cumulative Distribution Function for {dist_name} Distribution')
+    fig = go.Figure()
+    fig.add_trace(go.Scatter(x=x_range, y=cdf, mode='lines',
+                            name='', hovertemplate='x: %{x:.2f}<br>F(x): %{y:.2f}'))
+    fig.update_layout(xaxis_title='x', yaxis_title='F(x)', showlegend=False)
+
+    st.plotly_chart(fig)
+
+def plot_discrete_cdf(cdf, x_range, dist_name):
+    # Main plot area
+    st.markdown(f'#### Cumulative Distribution Function for {dist_name} Distribution')
+    fig = go.Figure()
+    fig.add_trace(go.Bar(x=x_range.tolist(), y=cdf.tolist(),
+                         name='', hovertemplate='x: %{x:.2f}<br>F(x): %{y:.2f}'))
+    fig.update_layout(xaxis_title='x', yaxis_title='F(x)', showlegend=False)
 
     st.plotly_chart(fig)

--- a/utils.py
+++ b/utils.py
@@ -17,10 +17,11 @@ def compute_pdf(dist, x_range, support):
     return pdf
 
 def compute_cdf(dist, x_range, support):
-    cdf = torch.zeros_like(x_range, dtype=torch.float)    
     pdf = compute_pdf(dist, x_range, support)
-    cdf = pdf.cumsum(dim=0)
+    step_size = (x_range[1] - x_range[0]) if len(x_range) > 1 else 1
+    cdf = (pdf * step_size).cumsum(dim=0)
     return cdf
+
 
 def plot_pdf(pdf, x_range, dist_name):
     # Main plot area


### PR DESCRIPTION
# what i added
I added cdf for all distributions. I plot line chart for continuous distributions and bar plot for discrete distributions. which can change with value change through sidebar.
# file changed
I change three files.
## 1. utils.py
  - add compute_cdf function
  - add plot_cdf function for line plot
  - add plot_discrete_cdf function for bar plot
## 2. Continuous.py
  - call plot_cdf to plot line chart of cdf
  ![image](https://github.com/user-attachments/assets/38a3e49d-35e1-4dbd-b201-22d6879116f1)

## 3. Discrete.py
  - call plot_discrete_cdf to plot bar chart of cdf
  ![image](https://github.com/user-attachments/assets/e9e23adc-c362-4738-ab7b-e79c81647f97)
